### PR TITLE
Use github.user if set in gitconfig  as repo owner

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -269,9 +269,12 @@ func setOwner(githubOpts *GitHubAPIOpts) (err error) {
 	}
 
 	// Use .gitconfig value.
-	githubOpts.OwnerName, err = gitconfig.Username()
+	githubOpts.OwnerName, err = gitconfig.GithubUser()
 	if err != nil {
-		return err
+		githubOpts.OwnerName, err = gitconfig.Username()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Confirm value is not blank.


### PR DESCRIPTION
depends on tcnksm/go-gitconfig#5

fixes the following error when `user.name` is set to the users full name:
```sh
$ ghr --stat
GET https://api.github.com/repos/Drew%!S(MISSING)tokes/go-stdiolog/releases: 404 Not Found []% 
```