### PR TITLE
Fix the overlapping order of http requests between deleting tag and creating release

### DIFF
--- a/release.go
+++ b/release.go
@@ -141,6 +141,10 @@ func DeleteRelease(apiOpts *GitHubAPIOpts) (err error) {
 		return err
 	}
 
+	// This is because sometimes process of creating release on GitHub is more
+	// fast than deleting tag.
+	time.Sleep(5 * time.Second)
+
 	// Set const value to tell other func there is no release
 	apiOpts.ID = ReleaseIDNotFound
 	apiOpts.UploadURL = ""


### PR DESCRIPTION
Sometimes the request of deleting tag finishes later than that of creating release.
Then the release becomes a draft unintentionally.
So I added a waiting after the request of deleting tag.