### PR TITLE
Added Name to solve issue with wrong heading

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -251,6 +251,7 @@ func (cli *CLI) Run(args []string) int {
 
 	// Prepare create release request
 	req := &github.RepositoryRelease{
+		Name:            github.String(tag),
 		TagName:         github.String(tag),
 		Prerelease:      github.Bool(prerelease),
 		Draft:           github.Bool(draft),


### PR DESCRIPTION
We have seen that the name of the PR has been added to the tag name. Setting the name of the release fixes the issue.