### PR TITLE
Add a slash at the end of endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note that environmental variable takes priority over gitconfig value.
 You can use `ghr` for GitHub Enterprise. Change API endpoint via the enviromental variable.
 
 ```bash
-$ export GITHUB_API=http://github.company.com/api/v3
+$ export GITHUB_API=http://github.company.com/api/v3/
 ```
 
 ## Example


### PR DESCRIPTION
The directory will disappear if there is no slash.

```sh
$ export GITHUB_API=http://github.company.com/api/v3
$ ghr -u foo v0.0.1 pkg
Failed to create GitHub release page: failed to get release: get release tag: invalid status: 406 Not Acceptable: GET https://github.company.com/api/repos/foo/bar/releases/tags/v0.0.1: 406
```

The ghr is very useful product. Many thanks @tcnksm .