### PR TITLE
formatting changes

### DIFF
--- a/ghr.go
+++ b/ghr.go
@@ -21,25 +21,25 @@ type GHR struct {
 func (g *GHR) CreateRelease(ctx context.Context, req *github.RepositoryRelease, recreate bool) (*github.RepositoryRelease, error) {
 
 	// When draft release creation is requested,
-	// create it witout any check (it can).
+	// create it without any check (it can).
 	if *req.Draft {
 		fmt.Fprintln(g.outStream, "==> Create a draft release")
 		return g.GitHub.CreateRelease(ctx, req)
 	}
 
-	// Check release is exist or not.
+	// Check release exists.
 	// If release is not found, then create a new release.
 	release, err := g.GitHub.GetRelease(ctx, *req.TagName)
 	if err != nil {
 		if err != RelaseNotFound {
 			return nil, errors.Wrap(err, "failed to get release")
 		}
-		Debugf("Release (with tag %s) is not found: create a new one",
+		Debugf("Release (with tag %s) not found: create a new one",
 			*req.TagName)
 
 		if recreate {
 			fmt.Fprintf(g.outStream,
-				"WARNING: '-recreate' is specified but release (%s) is not found",
+				"WARNING: '-recreate' is specified but release (%s) not found",
 				*req.TagName)
 		}
 
@@ -47,9 +47,9 @@ func (g *GHR) CreateRelease(ctx context.Context, req *github.RepositoryRelease, 
 		return g.GitHub.CreateRelease(ctx, req)
 	}
 
-	// recreae is not true. Then use that exiting release.
+	// recreate is not true. Then use that existing release.
 	if !recreate {
-		Debugf("Release (with tag %s) exists: use exsiting one",
+		Debugf("Release (with tag %s) exists: use existing one",
 			*req.TagName)
 
 		fmt.Fprintf(g.outStream, "WARNING: found release (%s). Use existing one.\n",
@@ -57,8 +57,8 @@ func (g *GHR) CreateRelease(ctx context.Context, req *github.RepositoryRelease, 
 		return release, nil
 	}
 
-	// When recreate is requested, delete exsiting release
-	// and create a new release.
+	// When recreate is requested, delete existing release and create a
+	// new release.
 	fmt.Fprintln(g.outStream, "==> Recreate a release")
 	if err := g.DeleteRelease(ctx, *release.ID, *req.TagName); err != nil {
 		return nil, err
@@ -79,8 +79,8 @@ func (g *GHR) DeleteRelease(ctx context.Context, ID int, tag string) error {
 		return err
 	}
 
-	// This is because sometimes process of creating release on GitHub is more
-	// fast than deleting tag.
+	// This is because sometimes the process of creating a release on GitHub
+	// is faster than deleting a tag.
 	time.Sleep(5 * time.Second)
 
 	return nil
@@ -113,7 +113,7 @@ func (g *GHR) UploadAssets(ctx context.Context, releaseID int, localAssets []str
 	}
 
 	if err := eg.Wait(); err != nil {
-		return errors.Wrap(err, "one of goroutines is failed")
+		return errors.Wrap(err, "one of the goroutines failed")
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func (g *GHR) DeleteAssets(ctx context.Context, releaseID int, localAssets []str
 	}
 
 	if err := eg.Wait(); err != nil {
-		return errors.Wrap(err, "one of goroutines is failed")
+		return errors.Wrap(err, "one of the goroutines failed")
 	}
 
 	return nil

--- a/ghr.go
+++ b/ghr.go
@@ -52,7 +52,7 @@ func (g *GHR) CreateRelease(ctx context.Context, req *github.RepositoryRelease, 
 		Debugf("Release (with tag %s) exists: use exsiting one",
 			*req.TagName)
 
-		fmt.Fprintf(g.outStream, "WARNING: found release (%s). Use existing one.",
+		fmt.Fprintf(g.outStream, "WARNING: found release (%s). Use existing one.\n",
 			*req.TagName)
 		return release, nil
 	}


### PR DESCRIPTION
This changes the following formatting:

`WARNING: found release (v0.1.4). Use existing one.--> Uploading: ...`

to:

```
WARNING: found release (v0.1.4). Use existing one.
--> Uploading: ...
```