### PR TITLE
Fix arguments check

### DIFF
--- a/github.go
+++ b/github.go
@@ -41,7 +41,7 @@ func NewGitHubClient(owner, repo, token string, urlStr string) (GitHub, error) {
 		return nil, errors.New("missing GitHub repository owner")
 	}
 
-	if len(owner) == 0 {
+	if len(repo) == 0 {
 		return nil, errors.New("missing GitHub repository name")
 	}
 


### PR DESCRIPTION
I found duplicate check for `owner` and think the latter is a typo of `repo` due to error message.
So I fixed it. please check it 🙏 
https://github.com/tcnksm/ghr/blob/a1cf5aa2a11f60e998c65a1eb4939e3aab08f5e7/github.go#L40-L42
https://github.com/tcnksm/ghr/blob/a1cf5aa2a11f60e998c65a1eb4939e3aab08f5e7/github.go#L44-L46