### PR TITLE
Small fixes GitHub

### DIFF
--- a/github.go
+++ b/github.go
@@ -58,7 +58,7 @@ func NewGitHubClient(owner, repo, token, urlStr string) (GitHub, error) {
 	}
 
 	if len(urlStr) == 0 {
-		return nil, errors.New("missgig GitHub API URL")
+		return nil, errors.New("missing GitHub API URL")
 	}
 
 	baseURL, err := url.ParseRequestURI(urlStr)
@@ -86,7 +86,7 @@ func (c *GitHubClient) SetUploadURL(urlStr string) error {
 	i := strings.Index(urlStr, "repos/")
 	parsedURL, err := url.ParseRequestURI(urlStr[:i])
 	if err != nil {
-		return errors.Wrap(err, "faield to parse upload URL")
+		return errors.Wrap(err, "failed to parse upload URL")
 	}
 
 	c.UploadURL = parsedURL

--- a/github.go
+++ b/github.go
@@ -69,7 +69,7 @@ func NewGitHubClient(owner, repo, token, urlStr string) (GitHub, error) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: token,
 	})
-	tc := oauth2.NewClient(oauth2.NoContext, ts)
+	tc := oauth2.NewClient(context.TODO(), ts)
 
 	client := github.NewClient(tc)
 	client.BaseURL = baseURL


### PR DESCRIPTION
Two smalls fixes for githun.go .. 🙏 

- Typos
- Replace oauth2.NoContext with context.TODO() since [oauth2.NoContext is deprecated](https://godoc.org/golang.org/x/oauth2#pkg-variables)

Thanks! 👍 