### PR TITLE
Fix to open file in a retry loop

### DIFF
--- a/github.go
+++ b/github.go
@@ -188,11 +188,6 @@ func (c *GitHubClient) UploadAsset(ctx context.Context, releaseID int64, filenam
 		return nil, errors.Wrap(err, "failed to get abs path")
 	}
 
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to open file")
-	}
-
 	opts := &github.UploadOptions{
 		// Use base name by default
 		Name: filepath.Base(filename),
@@ -204,6 +199,12 @@ func (c *GitHubClient) UploadAsset(ctx context.Context, releaseID int64, filenam
 			res *github.Response
 			err error
 		)
+
+		f, err := os.Open(filename)
+		if err != nil {
+			return errors.Wrap(err, "failed to open file")
+		}
+
 		asset, res, err = c.Repositories.UploadReleaseAsset(context.TODO(), c.Owner, c.Repo, releaseID, opts, f)
 		if err != nil {
 			return errors.Wrapf(err, "failed to upload release asset: %s", filename)


### PR DESCRIPTION
In my project (called ghbr), when I run the command below,

```
ghr v0.0.5 ./pkg/dist/v0.0.5/
```

I encountered the following error.

```
Failed to upload one of assets: one of the goroutines failed: failed to upload asset: /Users/kitagawa-shuhei/go/src/github.com/shuheiktgw/ghbr/pkg/dist/v0.0.5/ghbr_v0.0.5_linux_386.tar.gz: failed to upload release asset: /Users/kitagawa-shuhei/go/src/github.com/shuheiktgw/ghbr/pkg/dist/v0.0.5/ghbr_v0.0.5_linux_386.tar.gz: stat /Users/kitagawa-shuhei/go/src/github.com/shuheiktgw/ghbr/pkg/dist/v0.0.5/ghbr_v0.0.5_linux_386.tar.gz: use of closed file
```

The real problem was, that the target repository (shuheiktgw/ghbr) already have a release tagged as `v0.0.5` and [UploadReleasedAsset](https://github.com/tcnksm/ghr/blob/master/github.go#L207) failed with `422 Validation Failed`.

However, currently [the file is opened outside of a retry loop](https://github.com/tcnksm/ghr/blob/master/github.go#L191)  and if GitHub API request fails, the retry  fails since the file is already read in [UploadReleasedAsset](https://github.com/tcnksm/ghr/blob/master/github.go#L207) once.

So I fixed to open the file in a retry loop! 👍 
 