### PR TITLE
Add new option to skip execution of ghr if a release with a specified tag already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ $ ghr \
     -p NUM \          # Set amount of parallelism (Default is number of CPU)
     -delete \         # Delete release and its git tag in advance if it exists
     -draft \          # Release as draft (Unpublish)
+    -soft \           # Stop uploading if the same tag already exists
     -prerelease \     # Crate prerelease
     TAG PATH
 ```


### PR DESCRIPTION
Currently, ghr does not support any ways to stop overriding assets when a release with a specified tag already exists. (If you specify `--replace` to false, it just fails uploading assets and returns non-zero value. See https://github.com/tcnksm/ghr/pull/99! 👍 )

I personally think it would be great if I could skip the execution of ghr if a release with a given option already exist. So I added the option named `--soft` to achieve that! Thanks! 😄 