### PR TITLE
Fix typo in readme and help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ ghr \
     -replace          # Replace artifacts if it is already uploaded
     -draft \          # Release as draft (Unpublish)
     -soft \           # Stop uploading if the same tag already exists
-    -prerelease \     # Crate prerelease
+    -prerelease \     # Create prerelease
     TAG PATH
 ```
 

--- a/cli.go
+++ b/cli.go
@@ -392,7 +392,7 @@ Options:
 	Release as draft (Unpublish)
 
 -prerelease
-	Crate prerelease
+	Create prerelease
 
 -parallel=-1
 	Parallelization factor. This option limits amount of parallelism of


### PR DESCRIPTION
I think `crate` should be `create`