### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.13 as builder
 WORKDIR /app
 COPY . /app
 RUN cd /app \
-    && CGO_ENABLED=0 GOOS=linux make build \
-    && cp -a bin/ghr /go/bin/ghr
+    && CGO_ENABLED=0 GOOS=linux make build
 
 # Project Image Stage
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Project Build Stage
+FROM golang:1.13 as builder
+WORKDIR /app
+COPY . /app
+RUN cd /app \
+    && CGO_ENABLED=0 GOOS=linux make build \
+    && cp -a bin/ghr /go/bin/ghr
+
+# Project Image Stage
+FROM scratch
+COPY --from=builder /app/bin/ghr /go/bin/
+ENTRYPOINT [ "/go/bin/ghr" ]

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,9 @@ cover:
 
 .PHONY: release
 release: bump crossbuild upload
+
+# build a docker container
+.PHONY: container
+container:
+	docker build -t tcnksm/ghr:$(VERSION) .
+	docker tag tcnksm/ghr:$(VERSION) tcnksm/ghr:$(COMMIT)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Or you can use `go get` (you need to use go1.7 or later),
 $ go get -u github.com/tcnksm/ghr
 ```
 
+You can also run the [docker](https://www.docker.com/) container:
+
+```bash
+$ docker pull tcnksm/ghr
+```
+
 ## VS.
 
 - [aktau/github-release](https://github.com/aktau/github-release) - `github-release` can also create and edit releases and upload artifacts. It has many options. `ghr` is a simple alternative. And `ghr` will parallelize upload artifacts.


### PR DESCRIPTION
halo

- adds a `Dockerfile`
- adds a make target of `container` to build ghr container locally
- updates the README to include pulling the docker container

note: happy to help to get this going in docker hub