### PR TITLE
Store github test -repo and -owner in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ ghr
 .envrc
 *.test
 pkg
+constants.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
   - linux
   - osx
 script:
+  - cp constants.go.example constants.go
   - make test-all
 after_script:
   - goveralls

--- a/README.md
+++ b/README.md
@@ -116,15 +116,17 @@ $ go get -u github.com/tcnksm/ghr
 
 - [aktau/github-release](https://github.com/aktau/github-release) - `github-release` can also create and edit releases and upload artifacts. It has many options. `ghr` is a simple alternative. And `ghr` will parallelize upload artifacts.
 
-## Contribution
+## Contribute
 
 1. Fork ([https://github.com/tcnksm/ghr/fork](https://github.com/tcnksm/ghr/fork))
-2. Create a feature branch
-3. Commit your changes
-4. Rebase your local changes against the master branch
-5. Run test suite with the `make test` command and confirm that it passes
-6. Run `gofmt -s`
-7. Create new Pull Request
+2. Run `cp constants.go.example constants.go`
+3. Edit `constants.go` with your test repo and your Github acccount
+4. Create a feature branch
+5. Commit your changes
+6. Rebase your local changes against the master branch
+7. Run test suite with the `make test` command and confirm that it passes
+8. Run `gofmt -s`
+9. Create new Pull Request
 
 ## Author
 

--- a/constants.go.example
+++ b/constants.go.example
@@ -1,0 +1,6 @@
+package main
+
+const (
+	TestOwner = "ghtools"
+	TestRepo  = "github-api-test"
+)

--- a/constants.go.example
+++ b/constants.go.example
@@ -1,6 +1,9 @@
 package main
 
 const (
+	// TestOwner is the github account of your github token.
 	TestOwner = "ghtools"
+	// TestRepo is a repository which is used to upload, recreate and delete
+	// releases during testing. You will need sufficient privileges.
 	TestRepo  = "github-api-test"
 )

--- a/github_test.go
+++ b/github_test.go
@@ -13,11 +13,6 @@ import (
 	"github.com/google/go-github/github"
 )
 
-const (
-	TestOwner = "ghtools"
-	TestRepo  = "github-api-test"
-)
-
 func testGithubClient(t *testing.T) GitHub {
 	token := os.Getenv(EnvGitHubToken)
 	client, err := NewGitHubClient(TestOwner, TestRepo, token, defaultBaseURL)


### PR DESCRIPTION
This makes it easier for new contributors to run the tests. I tried to
run the tests according to the contribution guidelines in `README.md`.
Unfortunately the tests failed. From the error messages I could tell
that the repository and github account used for the tests are hard-coded
which is bad for more than one contributor.

By the way, this is my very first commit to a golang project. Any
feedback welcome! :heart: