### PR TITLE
Show the exact `gofmt` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $ go get -u github.com/tcnksm/ghr
 3. Commit your changes
 4. Rebase your local changes against the master branch
 5. Run test suite with the `make test` command and confirm that it passes
-6. Run `gofmt -s`
+6. Run `gofmt -s -w .`
 7. Create new Pull Request
 
 ## Author


### PR DESCRIPTION
This was another pitfall for me as a new contributor: I just typed in
`gofmt -s` and thought the command would hang.. After searching on the
internet I found out it's waiting on standard input. So, just improper
use of the command.