### PR TITLE
111 release without files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,23 @@ You can see release page [here](https://github.com/tcnksm/ghr-demo/releases/tag/
 
 ## Usage
 
-To use `ghr` is simple. After setting GitHub API token (see more on [GitHub API Token](#github-api-token) section), change GitHub repository root directory and run the following command,
+Using `ghr` is simple. After setting GitHub API token (see more on [GitHub API Token](#github-api-token) section), change into your repository root directory and run the following command:
 
 ```bash
-$ ghr [option] TAG PATH
+$ ghr [option] TAG [PATH]
 ```
 
-You must provide `TAG` (git tag) and `PATH` to artifacts you want to upload. You can specify a file or a directory. If you provide a directory, all files in that directory uploaded.
+You must provide `TAG` (git tag) and optionally a `PATH` to artifacts you want to upload. You can specify a file or a directory. If you provide a directory, all files in that directory will be uploaded.
 
-`ghr` assumes that you are in the GitHub repository root when executed. This is because normally the artifacts you want to upload to a GitHub Release page is in that repository or generated there. With this assumption, `ghr` *implicitly* reads repository URL from `.git/config` file. But You can change this kind of information via option, see [Options](#options) section.
+`ghr` assumes that you are in a git repository when executed. This is because normally the artifacts you want to upload to a GitHub Release page are in that repository or generated there. With this assumption, `ghr` *implicitly* reads repository URL from `.git/config` file. But you can change this kind of information, see [Options](#options) section.
 
 ### GitHub API Token
 
-To use `ghr`, you need to get a GitHub token with an account which has enough permissions to to create releases. To get token, first, visit GitHub account settings page, then go to Applications for the user. Here you can create a token in the Personal access tokens section. For a private repository you need `repo` scope and for a public repository you need `public_repo` scope.
+To use `ghr`, you need to get a GitHub token with an account which has enough permissions to create releases. To get a token, visit GitHub account settings page, then go to Applications for the user. Here you can create a token in the Personal access tokens section. For a private repository you need `repo` scope and for a public repository you need `public_repo` scope.
 
 When using `ghr`, you can set it via `GITHUB_TOKEN` env var, `-token` command line option or `github.token` property in `.gitconfig` file.
 
-For instance, to set it via environmental variable:
+For instance, to set it via environment variable:
 
 ```bash
 $ export GITHUB_TOKEN="....."
@@ -50,11 +50,11 @@ Or set it in `github.token` in gitconfig:
 $ git config --global github.token "....."
 ```
 
-Note that environmental variable takes priority over gitconfig value.
+Note that environment variable take precedence over gitconfig value.
 
 ### GitHub Enterprise
 
-You can use `ghr` for GitHub Enterprise. Change API endpoint via the environmental variable.
+You can use `ghr` for GitHub Enterprise. Change API endpoint via the environment variable.
 
 ```bash
 $ export GITHUB_API=http://github.company.com/api/v3/
@@ -62,7 +62,7 @@ $ export GITHUB_API=http://github.company.com/api/v3/
 
 ## Example
 
-To upload all package in `pkg` directory with tag `v0.1.0`
+To upload all files in `pkg/` directory with tag `v0.1.0`
 
 ```bash
 $ ghr v0.1.0 pkg/
@@ -104,7 +104,7 @@ If you are OSX user, you can use [Homebrew](http://brew.sh/):
 $ brew install ghr
 ```
 
-If you are in another platform, you can download binary from [release page](https://github.com/tcnksm/ghr/releases) and place it in `$PATH` directory.
+If you are on another platform, you can download a binary from our [release page](https://github.com/tcnksm/ghr/releases) and place it in `$PATH` directory.
 
 Or you can use `go get` (you need to use go1.7 or later),
 

--- a/cli.go
+++ b/cli.go
@@ -160,12 +160,18 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	parsedArgs := flags.Args()
-	if len(parsedArgs) != 2 {
+	Debugf("parsed args : %s", parsedArgs)
+	var tag, path string
+	switch len(parsedArgs) {
+	case 1:
+		tag, path = parsedArgs[0], ""
+	case 2:
+		tag, path = parsedArgs[0], parsedArgs[1]
+	default:
 		PrintRedf(cli.errStream,
-			"Invalid argument: you must set TAG and PATH name.\n")
+			"Invalid number of arguments: you must set a git TAG and optionally a PATH.\n")
 		return ExitCodeBadArgs
 	}
-	tag, path := parsedArgs[0], parsedArgs[1]
 
 	// Extract github repository owner username.
 	// If it's not provided via command line flag, read it from .gitconfig
@@ -349,12 +355,12 @@ func maskString(s string) string {
 	return s[:5] + "**** (masked)"
 }
 
-var helpText = `Usage: ghr [options...] TAG PATH
+var helpText = `Usage: ghr [options...] TAG [PATH]
 
 ghr is a tool to create Release on Github and upload your
 artifacts to it. ghr parallelizes upload of multiple artifacts.
 
-You must specify tag (e.g., v1.0.0) and PATH to local artifacts.
+You must specify TAG (e.g., v1.0.0) and an optional PATH to local artifacts.
 If PATH is directory, ghr globs all files in the directory and
 upload it. If PATH is a file then, upload only it.
 

--- a/local.go
+++ b/local.go
@@ -9,6 +9,10 @@ import (
 
 // LocalAssets contains the local objects to be uploaded
 func LocalAssets(path string) ([]string, error) {
+	if path == "" {
+		return make([]string, 0, 0), nil
+	}
+
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get abs path")
@@ -27,10 +31,6 @@ func LocalAssets(path string) ([]string, error) {
 	files, err := filepath.Glob(filepath.Join(path, "*"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to glob files")
-	}
-
-	if len(files) == 0 {
-		return nil, errors.New("no local assets are found")
 	}
 
 	assets := make([]string, 0, len(files))

--- a/local_test.go
+++ b/local_test.go
@@ -16,3 +16,14 @@ func TestLocalAssets(t *testing.T) {
 		t.Fatalf("localAssets number = %d, want %d", got, want)
 	}
 }
+
+func TestLocalEmptyAssets(t *testing.T) {
+	localAssets, err := LocalAssets("")
+	if err != nil {
+		t.Fatal("LocalAssets failed:", err)
+	}
+
+	if got, want := len(localAssets), 0; got != want {
+		t.Fatalf("localAssets number = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
fix #111 

Todo
- [ ] Decide if we want to make `PATH` part of the `options`. That would be simpler but would also break the current API as you have to put the options in front of `TAG`.


