### PR TITLE
Allow use of ENV Varaibles to run tests which upload to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ go get -u github.com/tcnksm/ghr
 2. Create a feature branch
 3. Commit your changes
 4. Rebase your local changes against the master branch
-5. Run test suite with the `make test` command and confirm that it passes
+5. Run test suite with the `make test` command and confirm that it passes using correct variables e.g. `GITHUB_TOKEN=$GITHUB_TOKEN TEST_REPO_OWNER=tcnksm TEST_REPO_NAME=ghr make test`
 6. Run `gofmt -s -w .`
 7. Create new Pull Request
 

--- a/github_test.go
+++ b/github_test.go
@@ -26,13 +26,11 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	owner := os.Getenv(EnvRepoOwner)
-	if owner != "" {
+	if owner := os.Getenv(EnvRepoOwner); owner != "" {
 		TestOwner = owner
 	}
 
-	repo := os.Getenv(EnvRepoName)
-	if repo != "" {
+	if repo := os.Getenv(EnvRepoName); repo != "" {
 		TestRepo = repo
 	}
 

--- a/github_test.go
+++ b/github_test.go
@@ -14,9 +14,31 @@ import (
 )
 
 const (
+	// EnvRepoOwner is an environment var for the repository owner on which the github release test is performed
+	EnvRepoOwner = "TEST_REPO_OWNER"
+	// EnvRepoName is an environment var for the name of repository on which the github release test is performed
+	EnvRepoName = "TEST_REPO_NAME"
+)
+
+var (
 	TestOwner = "ghtools"
 	TestRepo  = "github-api-test"
 )
+
+func TestMain(m *testing.M) {
+	owner := os.Getenv(EnvRepoOwner)
+	if owner != "" {
+		TestOwner = owner
+	}
+
+	repo := os.Getenv(EnvRepoName)
+	if repo != "" {
+		TestRepo = repo
+	}
+
+	code := m.Run()
+	os.Exit(code)
+}
 
 func testGithubClient(t *testing.T) GitHub {
 	token := os.Getenv(EnvGitHubToken)


### PR DESCRIPTION
Override variables that are used in tests through ENV Variables. So that others can tests cleanly without updating code.