### PR TITLE
fix lint warnings

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -155,7 +155,7 @@ func (cli *CLI) Run(args []string) int {
 
 	// Show version and check latest version release
 	if version {
-		fmt.Fprintf(cli.outStream, OutputVersion())
+		fmt.Fprint(cli.outStream, OutputVersion())
 		return ExitCodeOK
 	}
 

--- a/github_test.go
+++ b/github_test.go
@@ -122,7 +122,7 @@ func TestGitHubClient_Upload(t *testing.T) {
 
 	githubClient, ok := client.(*GitHubClient)
 	if !ok {
-		t.Fatal("Faield to asset to GithubClient")
+		t.Fatal("Failed to asset to GithubClient")
 	}
 
 	rc, url, err := githubClient.Repositories.DownloadReleaseAsset(

--- a/local.go
+++ b/local.go
@@ -10,7 +10,7 @@ import (
 // LocalAssets contains the local objects to be uploaded
 func LocalAssets(path string) ([]string, error) {
 	if path == "" {
-		return make([]string, 0, 0), nil
+		return []string{}, nil
 	}
 
 	path, err := filepath.Abs(path)


### PR DESCRIPTION
- printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006) go-staticcheck
- should use make([]string, 0) instead (S1019) go-staticcheck