### PR TITLE
Allow to use Generate Release Notes function of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ $ ghr \
     -draft \          # Release as draft (Unpublish)
     -soft \           # Stop uploading if the same tag already exists
     -prerelease \     # Create prerelease
+    -generatenotes \  # Generate Release Notes automatically (See below)
     TAG PATH
 ```
 
@@ -115,6 +116,12 @@ $ go get -u github.com/tcnksm/ghr
 ## VS.
 
 - [aktau/github-release](https://github.com/aktau/github-release) - `github-release` can also create and edit releases and upload artifacts. It has many options. `ghr` is a simple alternative. And `ghr` will parallelize upload artifacts.
+
+## Generate Release Notes
+
+GitHub added the ability to automatically generate the body of a Release based on a format specified in
+`.github/release.yml` in Oct 2021. You can read more about that format [here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes).
+ghr now has the `-generatenotes` flag to enable that content to be programmatically added instead of manually suppling the body.
 
 ## Contribution
 

--- a/cli.go
+++ b/cli.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/mitchellh/colorstring"
 	"github.com/tcnksm/go-gitconfig"
 )
@@ -95,6 +95,8 @@ func (cli *CLI) Run(args []string) int {
 		stat    bool
 		version bool
 		debug   bool
+
+		generatenotes bool
 	)
 
 	flags := flag.NewFlagSet(Name, flag.ContinueOnError)
@@ -139,6 +141,8 @@ func (cli *CLI) Run(args []string) int {
 	flags.BoolVar(&version, "v", false, "")
 
 	flags.BoolVar(&debug, "debug", false, "")
+
+	flags.BoolVar(&generatenotes, "generatenotes", false, "")
 
 	// Deprecated
 	flags.BoolVar(&stat, "stat", false, "")
@@ -271,12 +275,13 @@ func (cli *CLI) Run(args []string) int {
 
 	// Prepare create release request
 	req := &github.RepositoryRelease{
-		Name:            github.String(name),
-		TagName:         github.String(tag),
-		Prerelease:      github.Bool(prerelease),
-		Draft:           github.Bool(draft),
-		TargetCommitish: github.String(commitish),
-		Body:            github.String(body),
+		Name:                 github.String(name),
+		TagName:              github.String(tag),
+		Prerelease:           github.Bool(prerelease),
+		Draft:                github.Bool(draft),
+		TargetCommitish:      github.String(commitish),
+		Body:                 github.String(body),
+		GenerateReleaseNotes: github.Bool(generatenotes),
 	}
 
 	ctx := context.TODO()

--- a/cli.go
+++ b/cli.go
@@ -426,4 +426,7 @@ Options:
 
 -debug
 	Enable debug output
+
+-generatenotes
+	Generate the body of the release automatically based on .github/release.yml
 `

--- a/ghr.go
+++ b/ghr.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )

--- a/ghr_test.go
+++ b/ghr_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v39/github"
 )
 
 func TestGHR_CreateRelease(t *testing.T) {

--- a/github.go
+++ b/github.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Songmu/retry"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )

--- a/github_test.go
+++ b/github_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v39/github"
 )
 
 const (
@@ -153,7 +153,7 @@ func TestGitHubClient_Upload(t *testing.T) {
 	}
 
 	rc, url, err := githubClient.Repositories.DownloadReleaseAsset(
-		context.TODO(), githubClient.Owner, githubClient.Repo, *asset.ID)
+		context.TODO(), githubClient.Owner, githubClient.Repo, *asset.ID, http.DefaultClient)
 	if err != nil {
 		t.Fatal("DownloadReleaseAsset failed:", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/neilgierman/ghr
+module github.com/tcnksm/ghr
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tcnksm/ghr
+module github.com/neilgierman/ghr
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.16
 require (
 	github.com/Songmu/retry v0.1.0
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-github/v39 v39.2.0
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mattn/go-isatty v0.0.13 // indirect
@@ -18,6 +18,4 @@ require (
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
-	google.golang.org/appengine v1.6.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -87,10 +87,13 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvto3aSnQ=
+github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -151,6 +154,8 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -208,6 +213,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=


### PR DESCRIPTION
Upgrade go-github module to version that supports using the new Generate Release Notes function of GitHub Release and add that support to ghr.